### PR TITLE
Fix detection of `ssize_t` and `ptrdiff_t`: make `f()` `static` so that

### DIFF
--- a/kwsysPlatformTestsC.c
+++ b/kwsysPlatformTestsC.c
@@ -29,7 +29,7 @@
 
 #ifdef TEST_KWSYS_C_HAS_PTRDIFF_T
 #include <stddef.h>
-int f(ptrdiff_t n)
+static int f(ptrdiff_t n)
 {
   return n > 0;
 }
@@ -44,7 +44,7 @@ int KWSYS_PLATFORM_TEST_C_MAIN()
 
 #ifdef TEST_KWSYS_C_HAS_SSIZE_T
 #include <unistd.h>
-int f(ssize_t n)
+static int f(ssize_t n)
 {
   return (int)n;
 }


### PR DESCRIPTION
`gcc -Wmissing-prototypes -Werror` does not error out on the source file
even though the platform provides both `ssize_t` and `ptrdiff_t`.